### PR TITLE
add PR lint/test checks with logs and labels

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,4 +1,4 @@
-name: PR Check
+name: Exela CI
 
 on:
   pull_request:
@@ -10,7 +10,7 @@ permissions:
   issues: write
 
 jobs:
-  pr-checks:
+  meta-checks:
     runs-on: ubuntu-latest
 
     steps:
@@ -22,13 +22,19 @@ jobs:
           node-version: 18
 
       - name: Install dependencies
-        run: npm install
+        run: |
+          if [ -f package.json ]; then
+            echo "Root package.json found. Installing dependencies with npm ci..."
+            npm ci
+          else
+            echo "No root package.json found. Skipping root dependency installation."
+          fi
 
       - name: Run lint
         id: lint
         continue-on-error: true
         run: |
-          if npm run | grep -q "lint"; then
+          if [ -f package.json ] && npm run | grep -q "lint"; then
             echo "Lint script found. Running..."
             npm run lint 2>&1 | tee lint-output.txt
           else
@@ -124,3 +130,77 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: ci-passed
+
+  api:
+    name: API (Node) checks
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: api
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install API dependencies
+        run: npm ci
+
+      - name: Run API tests (if available)
+        id: api-test
+        continue-on-error: true
+        run: |
+          if npm run | grep -q "test"; then
+            echo "API test script found. Running..."
+            npm test --silent
+          else
+            echo "No API test script found; skipping tests."
+          fi
+
+  web:
+    name: Web client (React) checks
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: client
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install client dependencies
+        run: npm ci
+
+      - name: Run client lint
+        run: npm run lint
+
+      - name: Build client
+        run: npm run build
+
+  mobile:
+    name: Mobile app basic checks
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: mobile-app
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install mobile dependencies
+        run: npm ci

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,126 @@
+name: PR Check
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  pr-checks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        id: lint
+        continue-on-error: true
+        run: |
+          if npm run | grep -q "lint"; then
+            echo "Lint script found. Running..."
+            npm run lint 2>&1 | tee lint-output.txt
+          else
+            echo "No lint script found; skipping lint." | tee lint-output.txt
+          fi
+
+      - name: Run tests
+        id: test
+        continue-on-error: true
+        run: |
+          if npm run | grep -q "test"; then
+            echo "Test script found. Running..."
+            npm test --silent 2>&1 | tee test-output.txt
+          else
+            echo "No test script found; skipping tests." | tee test-output.txt
+          fi
+
+      - name: Post PR summary comment (with logs)
+        uses: actions/github-script@v7
+        env:
+          LINT_OUTCOME: ${{ steps.lint.outcome }}
+          TEST_OUTCOME: ${{ steps.test.outcome }}
+        with:
+          script: |
+            const fs = require("fs");
+
+            const pr = context.payload.pull_request;
+
+            const lintState = process.env.LINT_OUTCOME;
+            const testState = process.env.TEST_OUTCOME;
+
+            function emoji(state) {
+              if (state === "success") return "✅";
+              if (state === "failure") return "❌";
+              return "⚠️";
+            }
+
+            function safeRead(path) {
+              try {
+                return fs.readFileSync(path, "utf8");
+              } catch {
+                return "No output file found.";
+              }
+            }
+
+            let lintOutput = safeRead("lint-output.txt");
+            let testOutput = safeRead("test-output.txt");
+
+            const MAX = 3000;
+            if (lintOutput.length > MAX) lintOutput = lintOutput.slice(-MAX);
+            if (testOutput.length > MAX) testOutput = testOutput.slice(-MAX);
+
+            const body = `
+            **Automated PR checks completed**
+
+            - Lint: ${emoji(lintState)} \`${lintState}\`
+            - Tests: ${emoji(testState)} \`${testState}\`
+
+            <details>
+            <summary><strong>Lint output</strong></summary>
+
+            \`\`\`
+            ${lintOutput}
+            \`\`\`
+            </details>
+
+            <details>
+            <summary><strong>Test output</strong></summary>
+
+            \`\`\`
+            ${testOutput}
+            \`\`\`
+            </details>
+            `.trim();
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body
+            });
+
+      - name: Add label on failure
+        if: ${{ steps.test.outcome == 'failure' || steps.lint.outcome == 'failure' }}
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: tests-failed
+
+      - name: Add label on success
+        if: ${{ steps.test.outcome == 'success' && steps.lint.outcome == 'success' }}
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: ci-passed

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: 18
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Run lint
         id: lint

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -10,127 +10,6 @@ permissions:
   issues: write
 
 jobs:
-  meta-checks:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Use Node.js 18
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-
-      - name: Install dependencies
-        run: |
-          if [ -f package.json ]; then
-            echo "Root package.json found. Installing dependencies with npm ci..."
-            npm ci
-          else
-            echo "No root package.json found. Skipping root dependency installation."
-          fi
-
-      - name: Run lint
-        id: lint
-        continue-on-error: true
-        run: |
-          if [ -f package.json ] && npm run | grep -q "lint"; then
-            echo "Lint script found. Running..."
-            npm run lint 2>&1 | tee lint-output.txt
-          else
-            echo "No lint script found; skipping lint." | tee lint-output.txt
-          fi
-
-      - name: Run tests
-        id: test
-        continue-on-error: true
-        run: |
-          if npm run | grep -q "test"; then
-            echo "Test script found. Running..."
-            npm test --silent 2>&1 | tee test-output.txt
-          else
-            echo "No test script found; skipping tests." | tee test-output.txt
-          fi
-
-      - name: Post PR summary comment (with logs)
-        uses: actions/github-script@v7
-        env:
-          LINT_OUTCOME: ${{ steps.lint.outcome }}
-          TEST_OUTCOME: ${{ steps.test.outcome }}
-        with:
-          script: |
-            const fs = require("fs");
-
-            const pr = context.payload.pull_request;
-
-            const lintState = process.env.LINT_OUTCOME;
-            const testState = process.env.TEST_OUTCOME;
-
-            function emoji(state) {
-              if (state === "success") return "✅";
-              if (state === "failure") return "❌";
-              return "⚠️";
-            }
-
-            function safeRead(path) {
-              try {
-                return fs.readFileSync(path, "utf8");
-              } catch {
-                return "No output file found.";
-              }
-            }
-
-            let lintOutput = safeRead("lint-output.txt");
-            let testOutput = safeRead("test-output.txt");
-
-            const MAX = 3000;
-            if (lintOutput.length > MAX) lintOutput = lintOutput.slice(-MAX);
-            if (testOutput.length > MAX) testOutput = testOutput.slice(-MAX);
-
-            const body = `
-            **Automated PR checks completed**
-
-            - Lint: ${emoji(lintState)} \`${lintState}\`
-            - Tests: ${emoji(testState)} \`${testState}\`
-
-            <details>
-            <summary><strong>Lint output</strong></summary>
-
-            \`\`\`
-            ${lintOutput}
-            \`\`\`
-            </details>
-
-            <details>
-            <summary><strong>Test output</strong></summary>
-
-            \`\`\`
-            ${testOutput}
-            \`\`\`
-            </details>
-            `.trim();
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number,
-              body
-            });
-
-      - name: Add label on failure
-        if: ${{ steps.test.outcome == 'failure' || steps.lint.outcome == 'failure' }}
-        uses: actions-ecosystem/action-add-labels@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: tests-failed
-
-      - name: Add label on success
-        if: ${{ steps.test.outcome == 'success' && steps.lint.outcome == 'success' }}
-        uses: actions-ecosystem/action-add-labels@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: ci-passed
-
   api:
     name: API (Node) checks
     runs-on: ubuntu-latest
@@ -146,20 +25,28 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18
+          cache: npm
+          cache-dependency-path: api/package-lock.json
 
       - name: Install API dependencies
         run: npm ci
 
+      - name: Run API lint (if available)
+        run: |
+          if npm run | grep -q "lint"; then
+            npm run lint
+          else
+            echo "No lint script found in api"
+          fi
+
       - name: Run API tests (if available)
-        id: api-test
-        continue-on-error: true
         run: |
           if npm run | grep -q "test"; then
-            echo "API test script found. Running..."
             npm test --silent
           else
-            echo "No API test script found; skipping tests."
+            echo "No test script found in api"
           fi
+
 
   web:
     name: Web client (React) checks
@@ -176,18 +63,21 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18
+          cache: npm
+          cache-dependency-path: client/package-lock.json
 
       - name: Install client dependencies
         run: npm ci
 
-      - name: Run client lint
+      - name: Run client lint (MUST PASS)
         run: npm run lint
 
       - name: Build client
         run: npm run build
 
+
   mobile:
-    name: Mobile app basic checks
+    name: Mobile app checks
     runs-on: ubuntu-latest
 
     defaults:
@@ -201,6 +91,67 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18
+          cache: npm
+          cache-dependency-path: mobile-app/package-lock.json
 
       - name: Install mobile dependencies
         run: npm ci
+
+      - name: Run mobile lint (if available)
+        run: |
+          if npm run | grep -q "lint"; then
+            npm run lint
+          else
+            echo "No lint script found in mobile-app"
+          fi
+
+      - name: Run mobile tests (if available)
+        run: |
+          if npm run | grep -q "test"; then
+            npm test --silent
+          else
+            echo "No test script found in mobile-app"
+          fi
+
+
+  pr-summary:
+    name: PR Summary Comment
+    runs-on: ubuntu-latest
+    needs: [api, web, mobile]
+    if: always()
+
+    steps:
+      - name: Post PR summary comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            const results = {
+              api: "${{ needs.api.result }}",
+              web: "${{ needs.web.result }}",
+              mobile: "${{ needs.mobile.result }}",
+            };
+
+            function emoji(state) {
+              if (state === "success") return "✅";
+              if (state === "failure") return "❌";
+              return "⚠️";
+            }
+
+            const body = `
+            **Automated PR checks completed**
+
+            - API: ${emoji(results.api)} \`${results.api}\`
+            - Web: ${emoji(results.web)} \`${results.web}\`
+            - Mobile: ${emoji(results.mobile)} \`${results.mobile}\`
+
+            > Note: Lint is enforced. If any job shows ❌, fix lint/test errors in that project.
+            `.trim();
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body
+            });

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Install client dependencies
         run: npm ci
 
-      - name: Run client lint (MUST PASS)
+      - name: Run client lint
         run: npm run lint
 
       - name: Build client

--- a/client/..eslintrc.json
+++ b/client/..eslintrc.json
@@ -1,0 +1,30 @@
+// client/.eslintrc.json
+{
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended"
+  ],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": [
+    "react",
+    "react-hooks"
+  ],
+  "rules": {
+    "react/prop-types": "off",
+    "react/react-in-jsx-scope": "off",
+    "no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }]
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }
+}

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -1,0 +1,30 @@
+// client/.eslintrc.json
+{
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended"
+  ],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": [
+    "react",
+    "react-hooks"
+  ],
+  "rules": {
+    "react/prop-types": "off",
+    "react/react-in-jsx-scope": "off",
+    "no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }]
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR improves the pull request CI workflow by running lint and tests (when available) and posting a summary comment directly on the PR.

## What’s included
- Runs `npm run lint` if a lint script exists
- Runs `npm test` if a test script exists
- Captures and posts lint/test output in a PR comment (trimmed for GitHub limits)
- Adds PR labels based on results:
  - `tests-failed` when lint or tests fail
  - `ci-passed` when both lint and tests succeed

## Notes
- Lint/test steps use `continue-on-error: true` so the workflow always posts a summary comment.
- Workflow permissions were added to allow PR comments and labels.

## How to test
1. Open a PR to `main` or `develop`
2. Confirm the workflow runs
3. Confirm a PR comment is posted with lint/test results and logs
4. Confirm labels match the outcome
